### PR TITLE
Validate HuggingFace token before any computation

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -89,6 +89,9 @@ class Predictor(BasePredictor):
                 description="Print out compute/inference times and memory usage information",
                 default=False)
     ) -> Output:
+        if diarization and not huggingface_access_token:
+            raise ValueError("huggingface_access_token is required when diarization is enabled")
+
         with torch.inference_mode():
             asr_options = {
                 "temperatures": [temperature],


### PR DESCRIPTION
Moves the token presence check to the top of predict, before torch.inference_mode() and audio loading. Fails fast instead of wasting GPU time on transcription when diarization was never going to succeed.