### PR TITLE
Configure COG_USER_AGENT for input file downloads

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -12,6 +12,11 @@ import time
 import torch
 import ffmpeg
 
+os.environ.setdefault(
+    "COG_USER_AGENT",
+    "whisperx-replicate (+https://github.com/victor-upmeet/whisperx-replicate)"
+)
+
 compute_type = "float16"  # change to "int8" if low on GPU mem (may reduce accuracy)
 device = "cuda"
 whisper_arch = "./models/faster-whisper-large-v3"
@@ -89,12 +94,19 @@ class Predictor(BasePredictor):
             max_speakers: int = Input(
                 description="Maximum number of speakers if diarization is activated (leave blank if unknown)",
                 default=None),
+            user_agent: str = Input(
+                description="Override the User-Agent used to download the audio file. Useful when the host "
+                            "blocks the default value.",
+                default=None),
             debug: bool = Input(
                 description="Print out compute/inference times and memory usage information",
                 default=False)
     ) -> Output:
         if diarization and not huggingface_access_token:
             raise ValueError("huggingface_access_token is required when diarization is enabled")
+
+        if user_agent:
+            os.environ["COG_USER_AGENT"] = user_agent
 
         with torch.inference_mode():
             asr_options = {


### PR DESCRIPTION
Sets a project-identifying `COG_USER_AGENT` at module load so input file downloads don't use the default `python-requests/X.Y` UA, which some hosts reject (issue #18). Also exposes an optional `user_agent` input parameter for per-request overrides when a specific host needs a different value.

Relies on the `COG_USER_AGENT` env var introduced in replicate/cog#2620 (merged 2026-01-27), so the container needs a cog version that includes that change. With older cog, the env var is simply ignored and behavior is unchanged.

I haven't been able to test this against a real Replicate deployment — would appreciate a smoke check before merging.