### PR TITLE
Use logging.info for per-iteration language detection output

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -237,7 +237,7 @@ def detect_language(full_audio_file_path, segments_starts, language_detection_mi
             finally:
                 audio_segment_file_path.unlink()
 
-            print(f"Iteration {iteration} - Detected language: {language} ({language_probability:.2f})")
+            logging.info(f"Iteration {iteration} - Detected language: {language} ({language_probability:.2f})")
 
             detected = {"language": language, "probability": language_probability, "iterations": iteration}
             if best is None or language_probability > best["probability"]:


### PR DESCRIPTION
## Summary

Minor change: the per-iteration log line in `detect_language()` was still using `print()` — it was missed during the migration to `logging` in e9db11d. This switches it to `logging.info` to match the rest of the file (including the final "Detected language ... after N iterations" log).

The line is useful for debugging when language detection picks an unexpected language or doesn't converge, so it's kept rather than removed.

## Test plan

- [ ] No behavioral change — output goes through the logging handler instead of stdout directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)